### PR TITLE
Actualizar cronograma para el 1er cuatrimestre 2026 (#96)

### DIFF
--- a/_data/cronograma.csv
+++ b/_data/cronograma.csv
@@ -1,19 +1,18 @@
 fecha,actividad,tp,modalidad
-12/08/2025,[Nociones de gráficos por computadora](https://docs.google.com/presentation/d/13SGHD1smmkZSZ5RZ9af4C0v_oaSXpK5pQ8SAOGsQN9A),,Laboratorio
-19/08/2025,Sin Actividad – Día de la UTN,,
-26/08/2025,[Transformaciones](https://docs.google.com/presentation/d/1Swn4KPXrVTW7QMxvIhDQIjBaBsWQer4SY2m5mc6LVGQ),Presentacion TP Cero,Laboratorio
-02/09/2025,[Render Pipeline](https://docs.google.com/presentation/d/1RQRYWBX9S9Qc5kwJmT_d2ASb7UfFxnlxSpODgkhI440),,Virtual
-09/09/2025,Introducción al trabajo práctico cuatrimestral en MonoGame,Presentacion TP,Virtual
-16/09/2025,[Texturas y Nociones de Shaders](https://docs.google.com/presentation/d/1w1pWBYd3EHGwKs0o3v6ddjmhPZp5V6Hr-LEYHs5B3Mk),,Virtual
-23/09/2025,[Colisiones](https://docs.google.com/presentation/d/1t2SnnMUZaa1AEQ5Hbrp319otKu8lhjE5xv7vm5jPO4c) y Fragment Shader,Primera entrega del TP,Virtual
-30/09/2025,[Iluminación](https://docs.google.com/presentation/d/1nQ7xWib-3MoYDNirxEykiAHnsClffb00a57zjJyq7Zg),,Virtual
-07/10/2025,Práctica de shaders,,Laboratorio
-14/10/2025,[Shaders de Post-Procesado](https://docs.google.com/presentation/d/1kkOsSZJjFzbnZw1duE_E5TUtG-0bC0yRuDnhzPCD134),Segunda entrega del TP,Virtual
-21/10/2025,[Optimización](https://docs.google.com/presentation/d/1XiWBmhVaKx0pbjBbObiDiNE1Zf4Rgw7T26YmRFda4No),,Virtual
-28/10/2025,Práctica de shaders,Tercera entrega del TP,Laboratorio
-04/11/2025,Game engine workshop,,Laboratorio
-11/11/2025,Coloquio,,Laboratorio
-18/11/2025,Coloquio,Cuarta entrega del TP,Laboratorio
-25/11/2025,Presentación oral grupal del TP - Recuperatorio coloquio,Entrega final del TP,Laboratorio
-02/12/2025,Finalización del 2º Cuatrimestre,,
-03/03/2026,Última fecha firma de TP asignaturas Cuatrimestrales y Promociones,,
+31/03/2026,[Nociones de gráficos por computadora](https://docs.google.com/presentation/d/13SGHD1smmkZSZ5RZ9af4C0v_oaSXpK5pQ8SAOGsQN9A),,Laboratorio
+07/04/2026,[Transformaciones](https://docs.google.com/presentation/d/1Swn4KPXrVTW7QMxvIhDQIjBaBsWQer4SY2m5mc6LVGQ),TP Cero,Laboratorio
+14/04/2026,[Render Pipeline](https://docs.google.com/presentation/d/1RQRYWBX9S9Qc5kwJmT_d2ASb7UfFxnlxSpODgkhI440),,Virtual
+21/04/2026,[Introducción al trabajo práctico cuatrimestral en MonoGame](https://docs.google.com/presentation/d/1w1pWBYd3EHGwKs0o3v6ddjmhPZp5V6Hr-LEYHs5B3Mk),Presentación TP,Laboratorio
+28/04/2026,[Texturas y Nociones de Shaders](https://docs.google.com/presentation/d/1w1pWBYd3EHGwKs0o3v6ddjmhPZp5V6Hr-LEYHs5B3Mk),,Virtual
+05/05/2026,[Colisiones](https://docs.google.com/presentation/d/1t2SnnMUZaa1AEQ5Hbrp319otKu8lhjE5xv7vm5jPO4c) y Fragment Shader,Primera entrega del TP,Virtual
+12/05/2026,Practica de shaders,,Laboratorio
+19/05/2026,Sin Actividad – Turno de examen final Mayo,Segunda entrega del TP,-
+26/05/2026,[Iluminación](https://docs.google.com/presentation/d/1nQ7xWib-3MoYDNirxEykiAHnsClffb00a57zjJyq7Zg),,Virtual
+02/06/2026,[Shaders de Post-Procesado](https://docs.google.com/presentation/d/1kkOsSZJjFzbnZw1duE_E5TUtG-0bC0yRuDnhzPCD134),,Virtual
+09/06/2026,[Optimización](https://docs.google.com/presentation/d/1XiWBmhVaKx0pbjBbObiDiNE1Zf4Rgw7T26YmRFda4No),Tercera entrega del TP,Virtual
+16/06/2026,Game engine workshop,,Laboratorio
+23/06/2026,Coloquio,Cuarta entrega del TP,Presencial
+30/06/2026,Coloquio,,Presencial
+07/07/2026,Presentación oral grupal del TP - Recuperatorio coloquio,Entrega final del TP,Laboratorio
+11/07/2026,Finalización del 1º Cuatrimestre,,
+01/08/2026,Última fecha firma de TP asignaturas Cuatrimestrales y Promociones,,

--- a/calendar/index.md
+++ b/calendar/index.md
@@ -12,4 +12,4 @@ title: Calendario
 {% endfor -%}
 {: .cronograma }
 
-- [Calendario Académico](https://frba.utn.edu.ar/static/CALENDARIO2025.pdf)
+- [Calendario Académico](https://frba.utn.edu.ar/static/CalendarioAcademico2026.pdf)


### PR DESCRIPTION
* Actualizar cronograma para el 1er cuatrimestre 2026

* Actualizo cronograma, sin IA. porque aun no entiende lo que le pedimos

* saco clase duplicada, agrego practica de shaders y actualizo link al calendario academico